### PR TITLE
Added a proper Spigot icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
         <ul class="navbar-nav ml-auto">
             <li class="nav-item">
                 <a class="nav-link" href="https://www.spigotmc.org/resources/authors/craftorystudios.771540/">
-                    <i class="fas fa-cube"></i> Spigot
+                    <i class="fas fa-faucet"></i> Spigot
                 </a>
             </li>
             <li class="nav-item">

--- a/sourcecode/layout.gohtml
+++ b/sourcecode/layout.gohtml
@@ -28,7 +28,7 @@
         <ul class="navbar-nav ml-auto">
             <li class="nav-item">
                 <a class="nav-link" href="https://www.spigotmc.org/resources/authors/craftorystudios.771540/">
-                    <i class="fas fa-cube"></i> Spigot
+                    <i class="fas fa-faucet"></i> Spigot
                 </a>
             </li>
             <li class="nav-item">


### PR DESCRIPTION
Right now, the spigot link is displayed via a generic package icon.

![e17ec66b7bed97e7aa19be6bf728b72d](https://user-images.githubusercontent.com/3967898/99159706-63de2f00-26df-11eb-8245-d58cf63359ea.png)

This Pull Request changes it to the proper SpigotMC logo.
*(Note that it isn't actually the official SpigotMC logo. But since you are using FontAwesome, we can utilize a whole library of icons, which conveniently includes a faucet icon. And it pretty much looks alike...)*

![dbdbf73a0eada4fbb42b0bc1f0f370a0](https://user-images.githubusercontent.com/3967898/99159727-925c0a00-26df-11eb-98ed-b2f9f9a8805a.png)


I feel like this will be a small but worthwhile improvement :)