### PR TITLE
Fixed a few code smells

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 </head>
 <body data-project="craftory-studios">
 
-<nav class="navbar navbar-expand-md navbar-dark bg-dark main-nav d-none d-lg-block d-xl-block">
+<nav class="navbar navbar-expand-md navbar-dark bg-dark main-nav d-none d-lg-block d-xl-block" aria-labelledby="Top navigation">
     <div class="container">
         <ul class="navbar-nav">
             
@@ -43,7 +43,7 @@
     </div>
 </nav>
 
-<nav class="navbar navbar-expand-lg navbar-light bg-light">
+<nav class="navbar navbar-expand-lg navbar-light bg-light" aria-labelledby="Page navigation">
     <div class="container">
         <div class="d-flex">
         <div class="logo mr-3 mt-2 mb-2">

--- a/sourcecode/layout.gohtml
+++ b/sourcecode/layout.gohtml
@@ -14,7 +14,7 @@
 </head>
 <body data-project="{{.Project.Slug}}">
 
-<nav class="navbar navbar-expand-md navbar-dark bg-dark main-nav d-none d-lg-block d-xl-block">
+<nav class="navbar navbar-expand-md navbar-dark bg-dark main-nav d-none d-lg-block d-xl-block" aria-labelledby="Top navigation">
     <div class="container">
         <ul class="navbar-nav">
             {{range $i, $project := .Site.Projects}}
@@ -44,7 +44,7 @@
     </div>
 </nav>
 
-<nav class="navbar navbar-expand-lg navbar-light bg-light">
+<nav class="navbar navbar-expand-lg navbar-light bg-light" aria-labelledby="Page navigation">
     <div class="container">
         <div class="d-flex">
         <div class="logo mr-3 mt-2 mb-2">


### PR DESCRIPTION
This one adresses Rule `Web:S5255` as found on Sonarcloud:

https://sonarcloud.io/project/issues?fileUuids=AXWAh_Ib6ZXbWzya3yIa&id=CraftoryStudios_website&resolved=false&rules=Web%3AS5255

Aria labels are used to help guide users with visual impedents who use a screen reader.
Due to the duplicate `<nav>` declaration here, it is best practice in terms of accessibility to declare an aria-label.
Note that not all screen readers support `aria-label`, at least not at the point where I had my last workshop about accessibility, so `aria-labelledby` is to be used preferabbly.

I went with "Top navigation" and "Page navigation" here, but let me know if you come up with a more descriptive label.