### PR TITLE
Fixed missing link

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,12 +16,17 @@
 <nav class="navbar navbar-expand-md navbar-dark bg-dark main-nav d-none d-lg-block d-xl-block" aria-labelledby="Top navigation">
     <div class="container">
         <ul class="navbar-nav">
-            
+
                 <li class="nav-item">
                     <a class="pl-0 nav-link active"
                        href="/craftory-tech">Craftory Tech</a>
                 </li>
-            
+
+                <li class="nav-item">
+                    <a class="nav-link active"
+                       href="/craftory-utils">Craftory Utils</a>
+                </li>
+
         </ul>
 
         <ul class="navbar-nav ml-auto">
@@ -52,13 +57,11 @@
 <nav class="navbar navbar-expand-lg navbar-light bg-light" aria-labelledby="Page navigation">
     <div class="container">
         <div class="d-flex">
-        <div class="logo mr-3 mt-2 mb-2">
-            
-            <a class="navbar-brand" href="/craftory-tech">
-                &nbsp;
-            </a>
-            
-        </div>
+            <div class="logo mr-3 mt-2 mb-2">
+                <a class="navbar-brand" href="https://craftory.studio/">
+                    &nbsp;
+                </a>
+            </div>
         </div>
 
         <button class="navbar-toggler d-block d-lg-none d-xl-none" type="button" data-toggle="collapse"
@@ -70,7 +73,7 @@
 </nav>
 
 <main role="main" class="pb-4">
-    
+
     <div class="jumbotron bg-light pt-4 pb-5">
         <div class="container">
             <p class="lead">Craftory Studios aims to create Minecraft Spigot plugins that adds exciting new feature to vanilla without any client side installs, just join on a server and play! </p>

--- a/sourcecode/layout.gohtml
+++ b/sourcecode/layout.gohtml
@@ -53,13 +53,11 @@
 <nav class="navbar navbar-expand-lg navbar-light bg-light" aria-labelledby="Page navigation">
     <div class="container">
         <div class="d-flex">
-        <div class="logo mr-3 mt-2 mb-2">
-            {{if eq .Project.Name "Craftory Tech"}}
-            <a class="navbar-brand" href="/{{.Project.Slug}}">
-                &nbsp;
-            </a>
-            {{end}}
-        </div>
+            <div class="logo mr-3 mt-2 mb-2">
+                <a class="navbar-brand" href="https://craftory.studio/">
+                    &nbsp;
+                </a>
+            </div>
         </div>
 
         <button class="navbar-toggler d-block d-lg-none d-xl-none" type="button" data-toggle="collapse"


### PR DESCRIPTION
The top navigation was very inconsistent throughout pages, as seen here:

![99995060b46e90325180a3cd37e2a625](https://user-images.githubusercontent.com/3967898/99910471-89c28f80-2cee-11eb-9dee-a42736422e77.png)
![3f29c6e9eebe204fb9027ba50ae9e443](https://user-images.githubusercontent.com/3967898/99910474-8af3bc80-2cee-11eb-913c-7f477eb954bb.png)

This PR fixed that inconsistency.
And I am also proposing a change to the "brand-image", on both the main page and `/craftory-tech` it links to `/craftory-tech`.
On `/craftory-utils` however, it isn't clickable at all.
Normally the brand image should always link back to the root page.
So additionally this pull request also makes it always link to the root index.html

Especially because it says "Craftory Studios", not "Craftory Tech".