### PR TITLE
Added discord widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,12 +16,12 @@
 <nav class="navbar navbar-expand-md navbar-dark bg-dark main-nav d-none d-lg-block d-xl-block" aria-labelledby="Top navigation">
     <div class="container">
         <ul class="navbar-nav">
-            
+
                 <li class="nav-item">
                     <a class="pl-0 nav-link active"
                        href="/craftory-tech">Craftory Tech</a>
                 </li>
-            
+
         </ul>
 
         <ul class="navbar-nav ml-auto">
@@ -53,11 +53,11 @@
     <div class="container">
         <div class="d-flex">
         <div class="logo mr-3 mt-2 mb-2">
-            
+
             <a class="navbar-brand" href="/craftory-tech">
                 &nbsp;
             </a>
-            
+
         </div>
         </div>
 
@@ -70,19 +70,33 @@
 </nav>
 
 <main role="main" class="pb-4">
-    
+
     <div class="jumbotron bg-light pt-4 pb-5">
         <div class="container">
-            <p class="lead">Craftory Studios aims to create Minecraft Spigot plugins that adds exciting new feature to vanilla without any client side installs, just join on a server and play! </p>
+            <p class="lead">Craftory Studios aims to create Minecraft Spigot plugins that adds exciting new feature to
+                vanilla without any client side installs, just join on a server and play! </p>
 
             <hr class="my-4">
-            <p>Check out the links bellow to our plugins...</p>
 
-            <a class="btn btn-primary btn-lg" href="/craftory-tech/"
-               role="button">Craftory Tech</a>
+            <div class="row">
+                <div class="col-md-8">
+                    <p>Check out the links bellow to our plugins...</p>
 
-            <a class="btn btn-primary btn-lg" href="/craftory-utils/"
-               role="button">Craftory Utils</a>
+                    <a class="btn btn-primary btn-lg" href="/craftory-tech/" role="button">
+                        Craftory Tech</a>
+                    <a class="btn btn-primary btn-lg" href="/craftory-utils/" role="button">
+                        Craftory Utils</a>
+
+                    <!-- This nb-space enforces a readable mobile view -->
+                    <p>&nbsp;</p>
+                </div>
+
+                <div class="col-md-4">
+                    <iframe src="https://discord.com/widget?id=730061796093984840&amp;theme=light" allowtransparency="false"
+                        width="350" height="450" frameborder="0" sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts">
+                    </iframe>
+                </div>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
This Pull Request adds a nifty Discord Widget to the main page.
The widget is added as a sidebar to the right side of the main body, I went for the "light" discord theme here since the website as a whole is in a light theme.

*Craftory dark mode when? :eyes:*

Desktop version:
![58f243b2879da1397f42836150efa898](https://user-images.githubusercontent.com/3967898/99911038-0c991980-2cf2-11eb-8c81-6278fc9c9927.png)

Mobile version:
![4088e694df86011f8558c4507f18759a](https://user-images.githubusercontent.com/3967898/99911041-0dca4680-2cf2-11eb-8877-26c3e3cc716d.png)

(In order for the widget to work reliably, you may need to enable it in the Server Settings)